### PR TITLE
Entity-Riding and safe teleports

### DIFF
--- a/sponge/src/main/java/com/griefdefender/listener/CommonEntityEventHandler.java
+++ b/sponge/src/main/java/com/griefdefender/listener/CommonEntityEventHandler.java
@@ -120,6 +120,7 @@ public class CommonEntityEventHandler {
         GDTimings.ENTITY_MOVE_EVENT.startTimingIfSync();
         Player player = null;
         GDPermissionUser user = null;
+        boolean onMount = false;
         if (targetEntity instanceof Player) {
             player = (Player) targetEntity;
             user = PermissionHolderCache.getInstance().getOrCreateUser(player);
@@ -128,6 +129,7 @@ public class CommonEntityEventHandler {
             if (controller != null && controller instanceof Player) {
                 player = (Player) controller;
                 user = PermissionHolderCache.getInstance().getOrCreateUser(player);
+                onMount = true;
             } else {
                 user = PermissionHolderCache.getInstance().getOrCreateUser(targetEntity.getCreator().orElse(null));
             }
@@ -328,6 +330,18 @@ public class CommonEntityEventHandler {
             }
 
             if (player != null) {
+			    if (GDFlags.ENTITY_RIDING && onMount) {
+                    if (GDPermissionManager.getInstance().getFinalPermission(event, targetEntity.getLocation(), toClaim, Flags.ENTITY_RIDING, player, targetEntity, player, TrustTypes.ACCESSOR, true) == Tristate.FALSE) {
+                        Location<World> safeLocation = Sponge.getGame().getTeleportHelper()
+                                .getSafeLocation(fromLocation, 80, 0)
+                                .orElseGet(() -> Sponge.getGame().getTeleportHelper()
+                                        .getSafeLocation(fromLocation, 80, 6)
+                                        .orElse(world.getSpawnLocation())
+                                );
+                        targetEntity.getBaseVehicle().clearPassengers();
+                        player.setTransform(player.getTransform().setLocation(safeLocation));
+                    }
+                }
                 final GDPlayerData playerData = user.getInternalPlayerData();
                 final boolean showGpPrefix = GriefDefenderPlugin.getGlobalConfig().getConfig().message.enterExitShowGdPrefix;
                 playerData.lastClaim = new WeakReference<>(toClaim);
@@ -482,6 +496,13 @@ public class CommonEntityEventHandler {
             player.offer(Keys.CAN_FLY, false);
             player.offer(Keys.IS_FLYING, false);
             playerData.ignoreFallDamage = true;
+            Location<World> safeLocation = Sponge.getGame().getTeleportHelper()
+                    .getSafeLocation(player.getLocation(), 80, 0)
+                    .orElseGet(() -> Sponge.getGame().getTeleportHelper()
+                            .getSafeLocation(player.getLocation(), 80, 6)
+                            .orElse(player.getWorld().getSpawnLocation())
+                    );
+            player.setTransform(player.getTransform().setLocation(safeLocation));
             GriefDefenderPlugin.sendMessage(player, MessageCache.getInstance().OPTION_APPLY_PLAYER_DENY_FLIGHT);
         }
     }

--- a/sponge/src/main/java/com/griefdefender/listener/CommonEntityEventHandler.java
+++ b/sponge/src/main/java/com/griefdefender/listener/CommonEntityEventHandler.java
@@ -332,6 +332,7 @@ public class CommonEntityEventHandler {
             if (player != null) {
 			    if (GDFlags.ENTITY_RIDING && onMount) {
                     if (GDPermissionManager.getInstance().getFinalPermission(event, targetEntity.getLocation(), toClaim, Flags.ENTITY_RIDING, player, targetEntity, player, TrustTypes.ACCESSOR, true) == Tristate.FALSE) {
+                        event.setCancelled(true);
                         Location<World> safeLocation = Sponge.getGame().getTeleportHelper()
                                 .getSafeLocation(fromLocation, 80, 0)
                                 .orElseGet(() -> Sponge.getGame().getTeleportHelper()
@@ -340,6 +341,8 @@ public class CommonEntityEventHandler {
                                 );
                         targetEntity.getBaseVehicle().clearPassengers();
                         player.setTransform(player.getTransform().setLocation(safeLocation));
+                        GDTimings.ENTITY_MOVE_EVENT.stopTimingIfSync();
+                        return false;
                     }
                 }
                 final GDPlayerData playerData = user.getInternalPlayerData();

--- a/sponge/src/main/java/com/griefdefender/listener/EntityEventHandler.java
+++ b/sponge/src/main/java/com/griefdefender/listener/EntityEventHandler.java
@@ -919,7 +919,7 @@ public class EntityEventHandler {
     }
 
     @Listener(order = Order.FIRST, beforeModifications = true)
-    public void onEntityMount(RideEntityEvent event) {
+    public void onEntityMount(RideEntityEvent.Mount event) {
         if (!GDFlags.ENTITY_RIDING) {
             return;
         }


### PR DESCRIPTION
Slight fix to stop getting stuck on mounts, but I also added a safe teleport for entering claims that have enitiy riding or flying disabled. 
The reason the safe teleport doesn't try to look for safe blocks on the x or y axis is because I had some issues with it trying to teleport the place inside the claim which was blocked by the entity-teleport-to flag. 
The height is 80 as it expects players to be flying, although the downside is if the surface is unsafe they get sent underground.