### PR TITLE
Rename snow_layer to snow across the repo

### DIFF
--- a/bukkit/src/main/java/com/griefdefender/migrator/GriefPreventionMigrator.java
+++ b/bukkit/src/main/java/com/griefdefender/migrator/GriefPreventionMigrator.java
@@ -396,7 +396,7 @@ public class GriefPreventionMigrator {
                         PermissionUtil.getInstance().setPermissionValue(DEFAULT_HOLDER, Flags.ENTITY_DAMAGE.getPermission(), Tristate.FALSE, contexts);
                         break;
                     case FLAG_NO_SNOW_FORM :
-                        contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+                        contexts.add(FlagContexts.TARGET_SNOW);
                         PermissionUtil.getInstance().setPermissionValue(DEFAULT_HOLDER, Flags.BLOCK_MODIFY.getPermission(), Tristate.FALSE, contexts);
                         break;
                     case FLAG_NO_VEHICLE :

--- a/bukkit/src/main/java/com/griefdefender/migrator/WorldGuardMigrator.java
+++ b/bukkit/src/main/java/com/griefdefender/migrator/WorldGuardMigrator.java
@@ -522,7 +522,7 @@ public class WorldGuardMigrator {
                             }
                             break;
                         case "snow-fall": 
-                            contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+                            contexts.add(FlagContexts.TARGET_SNOW);
                             if (valueNode.getString().equals("deny")) {
                                 PERMISSION_MANAGER.setFlagPermission(Flags.BLOCK_PLACE, Tristate.FALSE, contexts);
                             } else {
@@ -530,7 +530,7 @@ public class WorldGuardMigrator {
                             }
                             break;
                         case "snow-melt": 
-                            contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+                            contexts.add(FlagContexts.TARGET_SNOW);
                             if (valueNode.getString().equals("deny")) {
                                 PERMISSION_MANAGER.setFlagPermission(Flags.BLOCK_BREAK, Tristate.FALSE, contexts);
                             } else {

--- a/bukkit/src/main/java/com/griefdefender/permission/flag/FlagContexts.java
+++ b/bukkit/src/main/java/com/griefdefender/permission/flag/FlagContexts.java
@@ -67,7 +67,7 @@ public class FlagContexts {
     public static final Context TARGET_PLAYER = new Context(ContextKeys.TARGET, "minecraft:player");
     public static final Context TARGET_ICE_FORM = new Context(ContextKeys.TARGET, "minecraft:ice");
     public static final Context TARGET_ICE_MELT = new Context(ContextKeys.TARGET, "minecraft:water");
-    public static final Context TARGET_SNOW_LAYER = new Context(ContextKeys.TARGET, "minecraft:snow_layer");
+    public static final Context TARGET_SNOW = new Context(ContextKeys.TARGET, "minecraft:snow");
     public static final Context TARGET_TURTLE_EGG = new Context(ContextKeys.TARGET, "minecraft:turtle_egg");
     public static final Context TARGET_VINE = new Context(ContextKeys.TARGET, "minecraft:vine");
     public static final Context TARGET_XP_ORB = new Context(ContextKeys.TARGET, "minecraft:xp_orb");

--- a/bukkit/src/main/java/com/griefdefender/permission/flag/GDFlagDefinitions.java
+++ b/bukkit/src/main/java/com/griefdefender/permission/flag/GDFlagDefinitions.java
@@ -332,11 +332,11 @@ public class GDFlagDefinitions {
         SLEEP = new GDFlagDefinition(Flags.INTERACT_BLOCK_SECONDARY, contexts, "sleep", MessageCache.getInstance().FLAG_DESCRIPTION_CUSTOM_SLEEP);
 
         contexts = new HashSet<>();
-        contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+        contexts.add(FlagContexts.TARGET_SNOW);
         SNOW_FALL = new GDFlagDefinition(Flags.BLOCK_PLACE, contexts, "snow-fall", MessageCache.getInstance().FLAG_DESCRIPTION_CUSTOM_SNOW_FALL);
 
         contexts = new HashSet<>();
-        contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+        contexts.add(FlagContexts.TARGET_SNOW);
         SNOW_MELT = new GDFlagDefinition(Flags.BLOCK_BREAK, contexts, "snow-melt", MessageCache.getInstance().FLAG_DESCRIPTION_CUSTOM_SNOW_MELT);
 
         contexts = new HashSet<>();

--- a/sponge/src/main/java/com/griefdefender/internal/visual/ClaimVisual.java
+++ b/sponge/src/main/java/com/griefdefender/internal/visual/ClaimVisual.java
@@ -510,7 +510,7 @@ public class ClaimVisual {
     }
 
     private boolean isTransparent(BlockState state) {
-        if (state.getType() == BlockTypes.SNOW_LAYER) {
+        if (state.getType() == BlockTypes.SNOW) {
             return false;
         }
 

--- a/sponge/src/main/java/com/griefdefender/migrator/GPBukkitMigrator.java
+++ b/sponge/src/main/java/com/griefdefender/migrator/GPBukkitMigrator.java
@@ -135,7 +135,7 @@ public class GPBukkitMigrator {
     private static final Context SOURCE_PLAYER = new Context(ContextKeys.SOURCE, "player");
     private static final Context TARGET_ICE_FORM = new Context(ContextKeys.TARGET, "ice");
     private static final Context TARGET_PLAYER = new Context(ContextKeys.TARGET, "player");
-    private static final Context TARGET_SNOW_LAYER = new Context("target", "snow_layer");
+    private static final Context TARGET_SNOW = new Context("target", "snow");
 
     public static void migrate(World world, Path gpClassicDataPath) throws FileNotFoundException, ClassNotFoundException {
         count = 0;
@@ -227,7 +227,7 @@ public class GPBukkitMigrator {
                         // TODO
                         break;
                     case FLAG_ENTER_MESSAGE :
-                        claimStorage.getConfig().setGreeting(LegacyComponentSerializer.legacy().deserialize(param, '§'));
+                        claimStorage.getConfig().setGreeting(LegacyComponentSerializer.legacy().deserialize(param, 'ï¿½'));
                         claimStorage.getConfig().setRequiresSave(true);
                         claimStorage.save();
                         break;
@@ -308,7 +308,7 @@ public class GPBukkitMigrator {
                         PermissionUtil.getInstance().setOptionValue(DEFAULT_HOLDER, Options.PLAYER_COMMAND_EXIT.getPermission(), param, contexts);
                         break;
                     case FLAG_EXIT_MESSAGE :
-                        claimStorage.getConfig().setFarewell(LegacyComponentSerializer.legacy().deserialize(param, '§'));
+                        claimStorage.getConfig().setFarewell(LegacyComponentSerializer.legacy().deserialize(param, 'ï¿½'));
                         claimStorage.getConfig().setRequiresSave(true);
                         claimStorage.save();
                         break;
@@ -400,7 +400,7 @@ public class GPBukkitMigrator {
                         PermissionUtil.getInstance().setPermissionValue(DEFAULT_HOLDER, Flags.ENTITY_DAMAGE.getPermission(), Tristate.FALSE, contexts);
                         break;
                     case FLAG_NO_SNOW_FORM :
-                        contexts.add(TARGET_SNOW_LAYER);
+                        contexts.add(TARGET_SNOW);
                         PermissionUtil.getInstance().setPermissionValue(DEFAULT_HOLDER, Flags.BLOCK_MODIFY.getPermission(), Tristate.FALSE, contexts);
                         break;
                     case FLAG_NO_VEHICLE :

--- a/sponge/src/main/java/com/griefdefender/migrator/WorldGuardMigrator.java
+++ b/sponge/src/main/java/com/griefdefender/migrator/WorldGuardMigrator.java
@@ -100,7 +100,7 @@ public class WorldGuardMigrator {
     static final Context TARGET_PLAYER = new Context("target", "player");
     static final Context TARGET_ICE_FORM = new Context("target", "ice");
     static final Context TARGET_ICE_MELT = new Context("target", "water");
-    static final Context TARGET_SNOW_LAYER = new Context("target", "snow_layer");
+    static final Context TARGET_SNOW = new Context("target", "snow");
     static final Context TARGET_TURTLE_EGG = new Context("target", "turtle_egg");
     static final Context TARGET_VINE = new Context("target", "vine");
     static final Context TARGET_XP_ORB = new Context("target", "xp_orb");
@@ -562,7 +562,7 @@ public class WorldGuardMigrator {
                             }
                             break;
                         case "snow-fall": 
-                            contexts.add(TARGET_SNOW_LAYER);
+                            contexts.add(TARGET_SNOW);
                             if (valueNode.getString().equals("deny")) {
                                 PERMISSION_MANAGER.setFlagPermission(Flags.BLOCK_PLACE, Tristate.FALSE, contexts);
                             } else {
@@ -570,7 +570,7 @@ public class WorldGuardMigrator {
                             }
                             break;
                         case "snow-melt": 
-                            contexts.add(TARGET_SNOW_LAYER);
+                            contexts.add(TARGET_SNOW);
                             if (valueNode.getString().equals("deny")) {
                                 PERMISSION_MANAGER.setFlagPermission(Flags.BLOCK_BREAK, Tristate.FALSE, contexts);
                             } else {

--- a/sponge/src/main/java/com/griefdefender/permission/flag/FlagContexts.java
+++ b/sponge/src/main/java/com/griefdefender/permission/flag/FlagContexts.java
@@ -67,7 +67,7 @@ public class FlagContexts {
     public static final Context TARGET_PLAYER = new Context(ContextKeys.TARGET, "minecraft:player");
     public static final Context TARGET_ICE_FORM = new Context(ContextKeys.TARGET, "minecraft:ice");
     public static final Context TARGET_ICE_MELT = new Context(ContextKeys.TARGET, "minecraft:water");
-    public static final Context TARGET_SNOW_LAYER = new Context(ContextKeys.TARGET, "minecraft:snow_layer");
+    public static final Context TARGET_SNOW = new Context(ContextKeys.TARGET, "minecraft:snow");
     public static final Context TARGET_TURTLE_EGG = new Context(ContextKeys.TARGET, "minecraft:turtle_egg");
     public static final Context TARGET_VINE = new Context(ContextKeys.TARGET, "minecraft:vine");
     public static final Context TARGET_XP_ORB = new Context(ContextKeys.TARGET, "minecraft:xp_orb");

--- a/sponge/src/main/java/com/griefdefender/permission/flag/GDFlagDefinitions.java
+++ b/sponge/src/main/java/com/griefdefender/permission/flag/GDFlagDefinitions.java
@@ -332,11 +332,11 @@ public class GDFlagDefinitions {
         SLEEP = new GDFlagDefinition(Flags.INTERACT_BLOCK_SECONDARY, contexts, "sleep", MessageCache.getInstance().FLAG_DESCRIPTION_CUSTOM_SLEEP);
 
         contexts = new HashSet<>();
-        contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+        contexts.add(FlagContexts.TARGET_SNOW);
         SNOW_FALL = new GDFlagDefinition(Flags.BLOCK_PLACE, contexts, "snow-fall", MessageCache.getInstance().FLAG_DESCRIPTION_CUSTOM_SNOW_FALL);
 
         contexts = new HashSet<>();
-        contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+        contexts.add(FlagContexts.TARGET_SNOW);
         SNOW_MELT = new GDFlagDefinition(Flags.BLOCK_BREAK, contexts, "snow-melt", MessageCache.getInstance().FLAG_DESCRIPTION_CUSTOM_SNOW_MELT);
 
         contexts = new HashSet<>();


### PR DESCRIPTION
As shown as per https://minecraft.gamepedia.com/Snow in 1.13 snow_layer was
renamed to snow. This changes every occurence of snow_layer to snow
accross the repo.