### PR TITLE
In bukkit, rename snow_layer to snow

### DIFF
--- a/bukkit/src/main/java/com/griefdefender/migrator/GriefPreventionMigrator.java
+++ b/bukkit/src/main/java/com/griefdefender/migrator/GriefPreventionMigrator.java
@@ -396,7 +396,7 @@ public class GriefPreventionMigrator {
                         PermissionUtil.getInstance().setPermissionValue(DEFAULT_HOLDER, Flags.ENTITY_DAMAGE.getPermission(), Tristate.FALSE, contexts);
                         break;
                     case FLAG_NO_SNOW_FORM :
-                        contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+                        contexts.add(FlagContexts.TARGET_SNOW);
                         PermissionUtil.getInstance().setPermissionValue(DEFAULT_HOLDER, Flags.BLOCK_MODIFY.getPermission(), Tristate.FALSE, contexts);
                         break;
                     case FLAG_NO_VEHICLE :

--- a/bukkit/src/main/java/com/griefdefender/migrator/WorldGuardMigrator.java
+++ b/bukkit/src/main/java/com/griefdefender/migrator/WorldGuardMigrator.java
@@ -522,7 +522,7 @@ public class WorldGuardMigrator {
                             }
                             break;
                         case "snow-fall": 
-                            contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+                            contexts.add(FlagContexts.TARGET_SNOW);
                             if (valueNode.getString().equals("deny")) {
                                 PERMISSION_MANAGER.setFlagPermission(Flags.BLOCK_PLACE, Tristate.FALSE, contexts);
                             } else {
@@ -530,7 +530,7 @@ public class WorldGuardMigrator {
                             }
                             break;
                         case "snow-melt": 
-                            contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+                            contexts.add(FlagContexts.TARGET_SNOW);
                             if (valueNode.getString().equals("deny")) {
                                 PERMISSION_MANAGER.setFlagPermission(Flags.BLOCK_BREAK, Tristate.FALSE, contexts);
                             } else {

--- a/bukkit/src/main/java/com/griefdefender/permission/flag/FlagContexts.java
+++ b/bukkit/src/main/java/com/griefdefender/permission/flag/FlagContexts.java
@@ -67,7 +67,7 @@ public class FlagContexts {
     public static final Context TARGET_PLAYER = new Context(ContextKeys.TARGET, "minecraft:player");
     public static final Context TARGET_ICE_FORM = new Context(ContextKeys.TARGET, "minecraft:ice");
     public static final Context TARGET_ICE_MELT = new Context(ContextKeys.TARGET, "minecraft:water");
-    public static final Context TARGET_SNOW_LAYER = new Context(ContextKeys.TARGET, "minecraft:snow_layer");
+    public static final Context TARGET_SNOW = new Context(ContextKeys.TARGET, "minecraft:snow");
     public static final Context TARGET_TURTLE_EGG = new Context(ContextKeys.TARGET, "minecraft:turtle_egg");
     public static final Context TARGET_VINE = new Context(ContextKeys.TARGET, "minecraft:vine");
     public static final Context TARGET_XP_ORB = new Context(ContextKeys.TARGET, "minecraft:xp_orb");

--- a/bukkit/src/main/java/com/griefdefender/permission/flag/GDFlagDefinitions.java
+++ b/bukkit/src/main/java/com/griefdefender/permission/flag/GDFlagDefinitions.java
@@ -332,11 +332,11 @@ public class GDFlagDefinitions {
         SLEEP = new GDFlagDefinition(Flags.INTERACT_BLOCK_SECONDARY, contexts, "sleep", MessageCache.getInstance().FLAG_DESCRIPTION_CUSTOM_SLEEP);
 
         contexts = new HashSet<>();
-        contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+        contexts.add(FlagContexts.TARGET_SNOW;
         SNOW_FALL = new GDFlagDefinition(Flags.BLOCK_PLACE, contexts, "snow-fall", MessageCache.getInstance().FLAG_DESCRIPTION_CUSTOM_SNOW_FALL);
 
         contexts = new HashSet<>();
-        contexts.add(FlagContexts.TARGET_SNOW_LAYER);
+        contexts.add(FlagContexts.TARGET_SNOW);
         SNOW_MELT = new GDFlagDefinition(Flags.BLOCK_BREAK, contexts, "snow-melt", MessageCache.getInstance().FLAG_DESCRIPTION_CUSTOM_SNOW_MELT);
 
         contexts = new HashSet<>();


### PR DESCRIPTION
This is to be consistent with a change that was made back in 2018 where
snow_layer was renamed to snow (version 1.13)

Source: https://minecraft.gamepedia.com/Snow

Sponge has been kept on the older version as currently my understanding
is Sponge doesn't support newer versions of the game.