### PR TITLE
Allow to input string as option value

### DIFF
--- a/bukkit/src/main/java/com/griefdefender/permission/option/GDOption.java
+++ b/bukkit/src/main/java/com/griefdefender/permission/option/GDOption.java
@@ -193,6 +193,8 @@ public class GDOption<T> implements Option<T> {
     public boolean validateStringValue(String value, boolean log) {
         if (value.equalsIgnoreCase("undefined")) {
             return false;
+        } else if (this.allowed == String.class) {
+            return true;
         } else if (this.allowed == List.class) {
             return true;
         } else if (this.allowed == Integer.class) {

--- a/sponge/src/main/java/com/griefdefender/permission/option/GDOption.java
+++ b/sponge/src/main/java/com/griefdefender/permission/option/GDOption.java
@@ -193,6 +193,8 @@ public class GDOption<T> implements Option<T> {
     public boolean validateStringValue(String value, boolean log) {
         if (value.equalsIgnoreCase("undefined")) {
             return false;
+        } else if (this.allowed == String.class) {
+            return true;
         } else if (this.allowed == List.class) {
             return true;
         } else if (this.allowed == Integer.class) {


### PR DESCRIPTION
I don't know if it was intended that `/claimoption` command is not able to set options with String value, but here's PR that allows to do it