### PR TITLE
Updated SlimefunProvider according to relocation of API classes.

### DIFF
--- a/bukkit/src/main/java/com/griefdefender/provider/SlimefunProvider.java
+++ b/bukkit/src/main/java/com/griefdefender/provider/SlimefunProvider.java
@@ -31,7 +31,7 @@ import org.bukkit.inventory.ItemStack;
 
 import com.griefdefender.api.permission.Context;
 
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 


### PR DESCRIPTION
Slimefun relocated some of their API classes, including SlimefunItem class.
https://github.com/Slimefun/Slimefun4/pull/3139